### PR TITLE
[nrf noup] sysflash: Add missing _FLASH_0_ID definitions

### DIFF
--- a/boot/zephyr/include/sysflash/pm_sysflash.h
+++ b/boot/zephyr/include/sysflash/pm_sysflash.h
@@ -84,4 +84,12 @@ static inline uint32_t __flash_area_ids_for_slot(int img, int slot)
 
 #endif /* CONFIG_SINGLE_APPLICATION_SLOT */
 
+#ifndef SOC_FLASH_0_ID
+#define SOC_FLASH_0_ID 0
+#endif
+
+#ifndef SPI_FLASH_0_ID
+#define SPI_FLASH_0_ID 1
+#endif
+
 #endif /* __PM_SYSFLASH_H__ */


### PR DESCRIPTION
MCUboot uses SOC_FLASH_0_ID and SPI_FLASH_0_ID to distinguish between internal and external boot device. These IDs are provided by sysflash.h, but the pm_sysflash.h overrides entire file, and was lacking that definitions.